### PR TITLE
Update Attributes.java

### DIFF
--- a/src/main/java/backtrace/io/data/Attributes.java
+++ b/src/main/java/backtrace/io/data/Attributes.java
@@ -17,6 +17,9 @@ import java.util.UUID;
  */
 class Attributes {
     private static final transient Logger LOGGER = LoggerFactory.getLogger(backtrace.io.data.Attributes.class);
+    
+    private static final String MACHINE_ID = generateMachineId();
+    
     /**
      * Gets built-in primitive attributes
      */
@@ -84,7 +87,7 @@ class Attributes {
             LOGGER.error("Can not get hostname", exception);
         }
 
-        this.attributes.put("guid", generateMachineId());
+        this.attributes.put("guid", MACHINE_ID);
 
         this.attributes.put("system.memory.total", Runtime.getRuntime().totalMemory());
         this.attributes.put("system.memory.free", Runtime.getRuntime().freeMemory());
@@ -96,7 +99,7 @@ class Attributes {
      *
      * @return unique device identifier
      */
-    private String generateMachineId() {
+    private static String generateMachineId() {
         try {
             InetAddress ip = InetAddress.getLocalHost();
 


### PR DESCRIPTION
Suggestion: generate `MACHINE_ID` statically. If the Mac address can't be queried (which is the case for me on Mac about 33% of the time, which is another thing to figure out), at least the random UUID is static within one session. Also, doing this for every report seems wasteful.