### PR TITLE
Fix the bug with excessive CPU usage by the backtrace-thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Backtrace Java Release Notes
 
+## Version 0.9.2 - 04.05.2021
+- Fix the [issue](https://github.com/backtrace-labs/backtrace-java/issues/4) with excessive CPU usage by the backtrace-thread
+
 ## Version 0.9.1 - 14.04.2020
 - Filter out stack traces from 'org.apache.log4j' and 'org.apache.logging'
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ We are working closely with users for their initial rollouts of backtrace-java. 
 * Gradle
 ```
 dependencies {
-    implementation 'com.github.backtrace-labs.backtrace-java:backtrace-java:0.9.1'
+    implementation 'com.github.backtrace-labs.backtrace-java:backtrace-java:0.9.2'
 }
 ```
 
@@ -26,7 +26,7 @@ dependencies {
 <dependency>
   <groupId>com.github.backtrace-labs.backtrace-java</groupId>
   <artifactId>backtrace-java</artifactId>
-  <version>0.9.1</version>
+  <version>0.9.2</version>
 </dependency>
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 apply from: 'publish.gradle'
 
 group = 'com.github.backtrace.io'
-version = '0.9.1'
+version = '0.9.2'
 
 repositories {
     jcenter()

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=0.9.1
+VERSION_NAME=0.9.2
 
 GROUP=com.github.backtrace-labs.backtrace-java
 

--- a/src/main/java/backtrace/io/Backtrace.java
+++ b/src/main/java/backtrace/io/Backtrace.java
@@ -28,15 +28,12 @@ class Backtrace {
         this.queue = queue;
     }
 
-
     /**
      * Handles the queue of incoming error reports
      */
     void handleBacktraceMessage() {
         try {
-            if (queue.isEmpty()) {
-                return;
-            }
+            this.queue.awaitNewMessage();
 
             BacktraceMessage message = queue.poll();
 
@@ -119,5 +116,9 @@ class Backtrace {
             report.incrementRetryCounter();
             this.queue.addWithLock(backtraceMessage);
         }
+    }
+
+    void close() {
+        this.queue.close();
     }
 }

--- a/src/main/java/backtrace/io/BacktraceQueue.java
+++ b/src/main/java/backtrace/io/BacktraceQueue.java
@@ -31,23 +31,32 @@ class BacktraceQueue extends ConcurrentLinkedQueue<BacktraceMessage> {
      * Unlock semaphore to inform that all messages from queue are sent
      */
     void unlock() {
+        LOGGER.debug("Releasing semaphore..");
+
+        if(notEmptyQueue.getCount() == 0) {
+            notEmptyQueue.countUp();
+        }
+
         if (lock.getCount() == 0) {
             return;
         }
-        LOGGER.debug("Releasing semaphore..");
+
         lock.countDown();
-        notEmptyQueue.countUp();
     }
 
     /**
      * Lock semaphore to inform that at least one of messages are processing
      */
     private void lock() {
+        if(notEmptyQueue.getCount() == 1) {
+            notEmptyQueue.countDown();
+        }
+
         if (lock.getCount() != 0) {
             return;
         }
+        
         LOGGER.debug("Locking semaphore..");
-        notEmptyQueue.countDown();
         lock.countUp();
         LOGGER.debug("Semaphore locked..");
     }

--- a/src/main/java/backtrace/io/BacktraceThread.java
+++ b/src/main/java/backtrace/io/BacktraceThread.java
@@ -47,6 +47,7 @@ public class BacktraceThread extends Thread {
     void close() throws InterruptedException {
         LOGGER.info("Closing BacktraceThread");
         this.running = false;
+        this.backtrace.close();
         this.closing.await();
     }
 


### PR DESCRIPTION
Fix the issue https://github.com/backtrace-labs/backtrace-java/issues/4 by adding extra semaphore which blocking backtrace-thread if queue is empty