### PR TITLE
[PATCH] Fix gson reflection not working for jdk internal types

### DIFF
--- a/src/main/java/backtrace/io/helpers/BacktraceSerializeHelper.java
+++ b/src/main/java/backtrace/io/helpers/BacktraceSerializeHelper.java
@@ -1,5 +1,7 @@
 package backtrace.io.helpers;
 
+import backtrace.io.serialization.StackTraceElementTypeAdapter;
+import backtrace.io.serialization.ThrowableTypeAdapter;
 import com.google.gson.FieldNamingPolicy;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -10,6 +12,12 @@ import com.google.gson.GsonBuilder;
  */
 public class BacktraceSerializeHelper {
 
+    private static final Gson gson = new GsonBuilder()
+            .registerTypeHierarchyAdapter(Throwable.class, new ThrowableTypeAdapter())
+            .registerTypeHierarchyAdapter(StackTraceElement.class, new StackTraceElementTypeAdapter())
+            .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_DASHES)
+            .create();
+
     /**
      * Serialize given object to JSON string
      *
@@ -17,7 +25,6 @@ public class BacktraceSerializeHelper {
      * @return serialized object in JSON string format
      */
     public static String toJson(Object object) {
-        Gson gson = new GsonBuilder().setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_DASHES).create();
         return gson.toJson(object);
     }
 
@@ -31,6 +38,6 @@ public class BacktraceSerializeHelper {
      * or if {@code json} is empty.
      */
     public static <T> T fromJson(String json, Class<T> type) {
-        return new Gson().fromJson(json, type);
+        return gson.fromJson(json, type);
     }
 }

--- a/src/main/java/backtrace/io/serialization/StackTraceElementTypeAdapter.java
+++ b/src/main/java/backtrace/io/serialization/StackTraceElementTypeAdapter.java
@@ -19,9 +19,6 @@ public class StackTraceElementTypeAdapter implements JsonSerializer<StackTraceEl
 
     private JsonElement toJson(StackTraceElement src) {
         JsonObject json = new JsonObject();
-        json.addProperty("classLoaderName", src.getClassLoaderName());
-        json.addProperty("moduleName", src.getModuleName());
-        json.addProperty("moduleVersion", src.getModuleVersion());
         json.addProperty("declaringClass", src.getClassName());
         json.addProperty("methodName", src.getMethodName());
         json.addProperty("fileName", src.getFileName());

--- a/src/main/java/backtrace/io/serialization/StackTraceElementTypeAdapter.java
+++ b/src/main/java/backtrace/io/serialization/StackTraceElementTypeAdapter.java
@@ -1,16 +1,23 @@
 package backtrace.io.serialization;
 
-import com.google.gson.*;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
 
 import java.lang.reflect.Type;
-import java.util.Arrays;
 
 public class StackTraceElementTypeAdapter implements JsonSerializer<StackTraceElement> {
 
-	@Override public JsonElement serialize(StackTraceElement src, Type typeOfSrc, JsonSerializationContext context) {
-		if (src == null) {
-			return null;
-		}
+    @Override
+    public JsonElement serialize(StackTraceElement src, Type typeOfSrc, JsonSerializationContext context) {
+        if (src == null) {
+            return null;
+        }
+		return toJson(src);
+	}
+
+	private JsonElement toJson(StackTraceElement src) {
 		JsonObject json = new JsonObject();
 		json.addProperty("classLoaderName", src.getClassLoaderName());
 		json.addProperty("moduleName", src.getModuleName());

--- a/src/main/java/backtrace/io/serialization/StackTraceElementTypeAdapter.java
+++ b/src/main/java/backtrace/io/serialization/StackTraceElementTypeAdapter.java
@@ -1,0 +1,25 @@
+package backtrace.io.serialization;
+
+import com.google.gson.*;
+
+import java.lang.reflect.Type;
+import java.util.Arrays;
+
+public class StackTraceElementTypeAdapter implements JsonSerializer<StackTraceElement> {
+
+	@Override public JsonElement serialize(StackTraceElement src, Type typeOfSrc, JsonSerializationContext context) {
+		if (src == null) {
+			return null;
+		}
+		JsonObject json = new JsonObject();
+		json.addProperty("classLoaderName", src.getClassLoaderName());
+		json.addProperty("moduleName", src.getModuleName());
+		json.addProperty("moduleVersion", src.getModuleVersion());
+		json.addProperty("declaringClass", src.getClassName());
+		json.addProperty("methodName", src.getMethodName());
+		json.addProperty("fileName", src.getFileName());
+		json.addProperty("lineNumber", src.getLineNumber());
+		return json;
+	}
+
+}

--- a/src/main/java/backtrace/io/serialization/StackTraceElementTypeAdapter.java
+++ b/src/main/java/backtrace/io/serialization/StackTraceElementTypeAdapter.java
@@ -14,19 +14,19 @@ public class StackTraceElementTypeAdapter implements JsonSerializer<StackTraceEl
         if (src == null) {
             return null;
         }
-		return toJson(src);
-	}
+        return toJson(src);
+    }
 
-	private JsonElement toJson(StackTraceElement src) {
-		JsonObject json = new JsonObject();
-		json.addProperty("classLoaderName", src.getClassLoaderName());
-		json.addProperty("moduleName", src.getModuleName());
-		json.addProperty("moduleVersion", src.getModuleVersion());
-		json.addProperty("declaringClass", src.getClassName());
-		json.addProperty("methodName", src.getMethodName());
-		json.addProperty("fileName", src.getFileName());
-		json.addProperty("lineNumber", src.getLineNumber());
-		return json;
-	}
+    private JsonElement toJson(StackTraceElement src) {
+        JsonObject json = new JsonObject();
+        json.addProperty("classLoaderName", src.getClassLoaderName());
+        json.addProperty("moduleName", src.getModuleName());
+        json.addProperty("moduleVersion", src.getModuleVersion());
+        json.addProperty("declaringClass", src.getClassName());
+        json.addProperty("methodName", src.getMethodName());
+        json.addProperty("fileName", src.getFileName());
+        json.addProperty("lineNumber", src.getLineNumber());
+        return json;
+    }
 
 }

--- a/src/main/java/backtrace/io/serialization/ThrowableTypeAdapter.java
+++ b/src/main/java/backtrace/io/serialization/ThrowableTypeAdapter.java
@@ -22,16 +22,16 @@ public class ThrowableTypeAdapter implements JsonSerializer<Throwable> {
             json.add("cause", cause);
         }
 
-		json.add("stackTrace", getStackTrace(src, context));
+        json.add("stackTrace", getStackTrace(src, context));
         return json;
     }
 
-	private JsonArray getStackTrace(Throwable src, JsonSerializationContext context) {
-		JsonArray trace = new JsonArray();
-		Arrays.stream(src.getStackTrace()).forEach(stackTraceElement -> {
-			trace.add(context.serialize(stackTraceElement));
-		});
-		return trace;
-	}
+    private JsonArray getStackTrace(Throwable src, JsonSerializationContext context) {
+        JsonArray trace = new JsonArray();
+        Arrays.stream(src.getStackTrace()).forEach(stackTraceElement -> {
+            trace.add(context.serialize(stackTraceElement));
+        });
+        return trace;
+    }
 
 }

--- a/src/main/java/backtrace/io/serialization/ThrowableTypeAdapter.java
+++ b/src/main/java/backtrace/io/serialization/ThrowableTypeAdapter.java
@@ -1,0 +1,28 @@
+package backtrace.io.serialization;
+
+import com.google.gson.*;
+
+import java.lang.reflect.Type;
+import java.util.Arrays;
+
+public class ThrowableTypeAdapter implements JsonSerializer<Throwable> {
+
+	@Override public JsonElement serialize(Throwable src, Type typeOfSrc, JsonSerializationContext context) {
+		if (src == null) {
+			return null;
+		}
+		JsonObject json = new JsonObject();
+		json.addProperty("detailMessage", src.getMessage());
+		var cause = context.serialize(src.getCause(), Throwable.class);
+		if (cause != null) {
+			json.add("cause", cause);
+		}
+		var trace = new JsonArray();
+		Arrays.stream(src.getStackTrace()).forEach(stackTraceElement -> {
+			trace.add(context.serialize(stackTraceElement));
+		});
+		json.add("stackTrace", trace);
+		return json;
+	}
+
+}

--- a/src/main/java/backtrace/io/serialization/ThrowableTypeAdapter.java
+++ b/src/main/java/backtrace/io/serialization/ThrowableTypeAdapter.java
@@ -7,22 +7,31 @@ import java.util.Arrays;
 
 public class ThrowableTypeAdapter implements JsonSerializer<Throwable> {
 
-	@Override public JsonElement serialize(Throwable src, Type typeOfSrc, JsonSerializationContext context) {
-		if (src == null) {
-			return null;
-		}
-		JsonObject json = new JsonObject();
-		json.addProperty("detailMessage", src.getMessage());
-		var cause = context.serialize(src.getCause(), Throwable.class);
-		if (cause != null) {
-			json.add("cause", cause);
-		}
-		var trace = new JsonArray();
+    @Override
+    public JsonElement serialize(Throwable src, Type typeOfSrc, JsonSerializationContext context) {
+        if (src == null) {
+            return null;
+        }
+
+        JsonObject json = new JsonObject();
+        json.addProperty("detailMessage", src.getMessage());
+
+        JsonElement cause = context.serialize(src.getCause(), Throwable.class);
+
+        if (cause != null) {
+            json.add("cause", cause);
+        }
+
+		json.add("stackTrace", getStackTrace(src, context));
+        return json;
+    }
+
+	private JsonArray getStackTrace(Throwable src, JsonSerializationContext context) {
+		JsonArray trace = new JsonArray();
 		Arrays.stream(src.getStackTrace()).forEach(stackTraceElement -> {
 			trace.add(context.serialize(stackTraceElement));
 		});
-		json.add("stackTrace", trace);
-		return json;
+		return trace;
 	}
 
 }


### PR DESCRIPTION
This will introduce a custom TypeAdapter to circumvent the default
reflection based Gson adapters.
Thanks @ahmed.mkaouar@saucelabs.com!